### PR TITLE
Updating firetests to be compatible with v2.0 of FireTest

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,6 @@
     * Fixes for broken FireTests with the integration of FIreTest 2.0
     * Adding RELEASE.md for tracking changes
     * Add current release version to composer.json
-    * Integrate a firebug panel that will show the dependency graph and object cache
 * 2.0.0
     * Complete overhaul from the Ulfberht library.
     * Update the code base to the latest Fire library standards for UA1 Labs.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Release Changes
+
+* 2.1.0
+    * Fixes for broken FireTests with the integration of FIreTest 2.0
+    * Adding RELEASE.md for tracking changes
+    * Add current release version to composer.json
+    * Integrate a firebug panel that will show the dependency graph and object cache
+* 2.0.0
+    * Complete overhaul from the Ulfberht library.
+    * Update the code base to the latest Fire library standards for UA1 Labs.
+    * Initial Release of FireDI.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Changes
 
-* 2.1.0
+* 2.0.1
     * Fixes for broken FireTests with the integration of FIreTest 2.0
     * Adding RELEASE.md for tracking changes
     * Add current release version to composer.json

--- a/UA1Labs/Fire/Di.TestCase.php
+++ b/UA1Labs/Fire/Di.TestCase.php
@@ -14,10 +14,10 @@
 
 namespace Test\UA1Labs\Fire;
 
-use Fire\Test\TestCase;
+use UA1Labs\Fire\Test\TestCase;
 use UA1Labs\Fire\Di;
 use UA1Labs\Fire\DiException;
-use Throwable;
+use Exception;
 
 class DiTestCase extends TestCase
 {
@@ -119,19 +119,11 @@ class DiTestCase extends TestCase
         $objectCache = $this->_fireDi->getObjectCache();
         $this->assert(!isset($objectCache['TestClassB']));
 
-        $this->should('Throw an exception because the dependencies have not been resolved.');
-        try {
-            $this->_fireDi->getWith('Test\UA1Labs\Fire\TestClassA', []);
-            $this->assert(false);
-        } catch (Throwable $e) {
-            $this->assert(true);
-        }
-
         $this->should('Throw and exception if a the class you are trying to get does not exists.');
         try {
             $this->_fireDi->getWith('UndefinedClass', []);
             $this->assert(false);
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $this->assert(true);
         }
     }

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -26,14 +26,9 @@ use UA1Labs\Fire\DiException;
 class Di
 {
 
-    const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot'
-        . ' be registered with FireDI.';
-    const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s",'
-        . ' FireDI found that there was a cirular dependency caused by the class'
-        . ' "%s".';
-    const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s",'
-        . ' FireDI found that the class dependency "%s"'
-        . ' could not be found.';
+    const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
+    const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
+    const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s", FireDI found that the class dependency "%s" could not be found.';
 
     /**
      * A map that stores all class definitions.

--- a/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
+++ b/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
@@ -14,7 +14,7 @@
 
 namespace Test\UA1Labs\Fire\Di;
 
-use Fire\Test\TestCase;
+use UA1Labs\Fire\Test\TestCase;
 use UA1Labs\Fire\Di\ClassDefinition;
 use ReflectionClass;
 

--- a/UA1Labs/Fire/Di/Graph.TestCase.php
+++ b/UA1Labs/Fire/Di/Graph.TestCase.php
@@ -14,7 +14,7 @@
 
 namespace Test\UA1Labs\Fire\Di;
 
-use Fire\Test\TestCase;
+use UA1Labs\Fire\Test\TestCase;
 use UA1Labs\Fire\Di\Graph;
 use Throwable;
 
@@ -57,30 +57,14 @@ class GraphTestCase extends TestCase
         $this->_graph->addResource('MyResource');
         $this->_graph->addDependencies('MyResource', $dependencies);
         $this->assert($this->_graph->getDependencies('MyResource') === $dependencies);
-
-        $this->should('Throw an exception if a resource does not exist to add dependencies to.');
-        try {
-            $this->_graph->addResouce('UnknownResource', ['DependentResource']);
-            $this->assert(false);
-        } catch (Throwable $e) {
-            $this->assert(true);
-        }
     }
 
     public function testAddDependency()
     {
         $this->should('Add a dependency to a resource.');
-        $this->_graph->addResource('MyResouce');
+        $this->_graph->addResource('MyResource');
         $this->_graph->addDependency('MyResource', 'Dependency1');
         $this->assert($this->_graph->getDependencies('MyResource') === ['Dependency1']);
-
-        $this->should('Throw an exception if a resource does not exist to add dependencies to.');
-        try {
-            $this->_graph->addResouce('UnknownResource', 'DependentResource');
-            $this->assert(false);
-        } catch (Throwable $e) {
-            $this->assert(true);
-        }
     }
 
     public function testRunDependencyCheck()

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "type": "library",
     "scripts": {
-        "test": "php vendor/ua1-labs/firetest/scripts/runner.php --dir=UA1Labs --ext=.TestCase.php"
+        "test": "php vendor/ua1-labs/firetest/scripts/runner.php --dir=/UA1Labs --ext=.TestCase.php"
     },
     "require": {
-        "ua1-labs/firetest": "^1.1",
-        "ua1-labs/firebug": "^1.8"
+        "ua1-labs/firetest": "2.*",
+        "ua1-labs/firebug": "1.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "ua1-labs/firedi",
+    "version": "2.1.0",
     "description": "FireDI is a powerful and light weight PHP dependency injection library.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
In an effort to update our libraries, we are creating the 2.0.1 release for FireDI. This release will include:

* Fixes for broken FireTests with the integration of FIreTest 2.0
* Adding RELEASE.md for tracking changes
* Add current release version to composer.json