### PR TITLE
Release 2.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 UA1 Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Changes
-
+* 2.1.0
+    * Move firetest and firebug into require-dev in composer.json
+    * Rename Di::put() to Di::set() and update the logic so that it will accept a closure to return the object.
+    * Implement the PSR-11 Container Interface standard
+    * Fix all docblocks. Add leading "\" to classes. Remove "_" from private variables/methods.
+    * Include MIT License
 * 2.0.1
     * Fixes for broken FireTests with the integration of FIreTest 2.0
     * Adding RELEASE.md for tracking changes

--- a/UA1Labs/Fire/Di.TestCase.php
+++ b/UA1Labs/Fire/Di.TestCase.php
@@ -26,29 +26,29 @@ class DiTestCase extends TestCase
      *
      * @var Di
      */
-    private $_fireDi;
+    private $fireDi;
 
     public function beforeEach()
     {
-        $this->_fireDi = new Di();
+        $this->fireDi = new Di();
     }
 
     public function afterEach()
     {
-        unset($this->_fireDi);
+        unset($this->fireDi);
     }
 
     public function testConstructor()
     {
         $this->should('The constructor should not throw an execption and be an instance of Di.');
-        $this->assert($this->_fireDi instanceof Di);
+        $this->assert($this->fireDi instanceof Di);
     }
 
     public function testPutObject()
     {
         $this->should('Put an object in the cache without an exception.');
         try {
-            $this->_fireDi->put('TestObject', new TestClassC());
+            $this->fireDi->put('TestObject', new TestClassC());
             $this->assert(true);
         } catch (DiException $e) {
             $this->assert(false);
@@ -58,11 +58,11 @@ class DiTestCase extends TestCase
     public function testGetObject()
     {
         $this->should('Resolve all dependencies for TestClassA and return the TestClassA object.');
-        $testClassA = $this->_fireDi->get('Test\UA1Labs\Fire\TestClassA');
+        $testClassA = $this->fireDi->get('Test\UA1Labs\Fire\TestClassA');
         $this->assert($testClassA instanceof TestClassA);
 
         $this->should('Have placed TestClassA, TestClassB, and TestClassC within the object cache.');
-        $objectCache = $this->_fireDi->getObjectCache();
+        $objectCache = $this->fireDi->getObjectCache();
         $this->assert(
             isset($objectCache['Test\UA1Labs\Fire\TestClassA'])
             && isset($objectCache['Test\UA1Labs\Fire\TestClassB'])
@@ -72,10 +72,10 @@ class DiTestCase extends TestCase
             && $objectCache['Test\UA1Labs\Fire\TestClassC'] instanceof TestClassC
         );
 
-        $this->_fireDi->clearObjectCache();
+        $this->fireDi->clearObjectCache();
 
         $this->should('Resolve all dependencies for TestClassD and return it.');
-        $testClassD = $this->_fireDi->get('Test\UA1Labs\Fire\TestClassD');
+        $testClassD = $this->fireDi->get('Test\UA1Labs\Fire\TestClassD');
         $this->assert($testClassD instanceof TestClassD);
 
         $this->should('Have set ::A as TestClassA on TestClassD object.');
@@ -89,7 +89,7 @@ class DiTestCase extends TestCase
 
         $this->should('Throw an exception if a the class you are trying to get does not exists.');
         try {
-            $this->_fireDi->get('UndefinedClass');
+            $this->fireDi->get('UndefinedClass');
             $this->assert(false);
         } catch (DiException $e) {
             $this->assert(true);
@@ -97,7 +97,7 @@ class DiTestCase extends TestCase
 
         $this->should('Throw an exception if a circular dependency is detected.');
         try {
-            $this->_fireDi->get('Test\UA1Labs\Fire\TestClassAA');
+            $this->fireDi->get('Test\UA1Labs\Fire\TestClassAA');
             $this->assert(false);
         } catch (DiException $e) {
             $this->assert(true);
@@ -107,21 +107,21 @@ class DiTestCase extends TestCase
     public function testGetWithObject()
     {
         $this->should('Return a TestClassB object.');
-        $testClassC = $this->_fireDi->get('Test\UA1Labs\Fire\TestClassC');
+        $testClassC = $this->fireDi->get('Test\UA1Labs\Fire\TestClassC');
         $dependencies = [$testClassC];
-        $testClassB = $this->_fireDi->getWith('Test\UA1Labs\Fire\TestClassB', $dependencies);
+        $testClassB = $this->fireDi->getWith('Test\UA1Labs\Fire\TestClassB', $dependencies);
         $this->assert($testClassB instanceof TestClassB);
 
         $this->should('Prove that TestClassB has a $C variable that is TestClassC.');
         $this->assert($testClassB->C instanceof TestClassC);
 
         $this->should('Prove that the object cache does not contain a TestClassB');
-        $objectCache = $this->_fireDi->getObjectCache();
+        $objectCache = $this->fireDi->getObjectCache();
         $this->assert(!isset($objectCache['TestClassB']));
 
         $this->should('Throw and exception if a the class you are trying to get does not exists.');
         try {
-            $this->_fireDi->getWith('UndefinedClass', []);
+            $this->fireDi->getWith('UndefinedClass', []);
             $this->assert(false);
         } catch (Exception $e) {
             $this->assert(true);
@@ -130,8 +130,8 @@ class DiTestCase extends TestCase
 
     public function testGetObjectCache()
     {
-        $this->_fireDi->put('TestObject', new TestClassC());
-        $objectCache = $this->_fireDi->getObjectCache();
+        $this->fireDi->put('TestObject', new TestClassC());
+        $objectCache = $this->fireDi->getObjectCache();
 
         $this->should('Return an object cache array with a key "TestObject".');
         $this->assert(isset($objectCache['TestObject']));
@@ -143,9 +143,9 @@ class DiTestCase extends TestCase
     public function testClearObjectCache()
     {
         $this->should('Remove all objects from the object cache');
-        $this->_fireDi->put('TestObject', new TestClassC());
-        $this->_fireDi->clearObjectCache();
-        $objectCache = $this->_fireDi->getObjectCache();
+        $this->fireDi->put('TestObject', new TestClassC());
+        $this->fireDi->clearObjectCache();
+        $objectCache = $this->fireDi->getObjectCache();
         $this->assert(empty($objectCache));
     }
 }

--- a/UA1Labs/Fire/Di.TestCase.php
+++ b/UA1Labs/Fire/Di.TestCase.php
@@ -14,17 +14,17 @@
 
 namespace Test\UA1Labs\Fire;
 
-use UA1Labs\Fire\Test\TestCase;
-use UA1Labs\Fire\Di;
-use UA1Labs\Fire\DiException;
-use Exception;
+use \UA1Labs\Fire\Test\TestCase;
+use \UA1Labs\Fire\Di;
+use \UA1Labs\Fire\DiException;
+use \Exception;
 
 class DiTestCase extends TestCase
 {
     /**
      * The FireDi
      *
-     * @var Di
+     * @var \UA1Labs\Fire\Di
      */
     private $fireDi;
 

--- a/UA1Labs/Fire/Di.TestCase.php
+++ b/UA1Labs/Fire/Di.TestCase.php
@@ -17,6 +17,7 @@ namespace Test\UA1Labs\Fire;
 use \UA1Labs\Fire\Test\TestCase;
 use \UA1Labs\Fire\Di;
 use \UA1Labs\Fire\DiException;
+use \UA1Labs\Fire\Di\NotFoundException;
 use \Exception;
 
 class DiTestCase extends TestCase
@@ -48,11 +49,34 @@ class DiTestCase extends TestCase
     {
         $this->should('Put an object in the cache without an exception.');
         try {
-            $this->fireDi->put('TestObject', new TestClassC());
+            $this->fireDi->set('TestObject', new TestClassC());
             $this->assert(true);
         } catch (DiException $e) {
             $this->assert(false);
         }
+    }
+
+    public function testHasObject()
+    {
+        $this->should('Return true when a class can be resolved.');
+        $result = $this->fireDi->has('\Test\UA1Labs\Fire\TestClassC');
+        $this->assert($result === true);
+        $this->fireDi->clearObjectCache();
+
+        $this->should('Return false when a class has a dependency that cannot be resolved.');
+        $result = $this->fireDi->has('\Test\UA1Labs\Fire\TestClassCC');
+        $this->assert($result === false);
+        $this->fireDi->clearObjectCache();
+
+        $this->should('Return false when a class has a circular dependency issue.');
+        $result = $this->fireDi->has('\Test\UA1Labs\Fire\TestClassAA');
+        $this->assert($result === false);
+        $this->fireDi->clearObjectCache();
+
+        $this->should('Return false when a class does not exist.');
+        $result = $this->fireDi->has('Undefined');
+        $this->assert($result === false);
+        $this->fireDi->clearObjectCache();
     }
 
     public function testGetObject()
@@ -87,19 +111,19 @@ class DiTestCase extends TestCase
         $this->should('Have set ::C as TestClassC on TestClassB.');
         $this->assert(isset($testClassD->B->C) && $testClassD->B->C instanceof TestClassC);
 
-        $this->should('Throw an exception if a the class you are trying to get does not exists.');
+        $this->should('Throw a NotFoundException if a the class you are trying to get does not exists.');
         try {
             $this->fireDi->get('UndefinedClass');
             $this->assert(false);
-        } catch (DiException $e) {
+        } catch (NotFoundException $e) {
             $this->assert(true);
         }
 
-        $this->should('Throw an exception if a circular dependency is detected.');
+        $this->should('Throw a NotFoundException if a circular dependency is detected.');
         try {
             $this->fireDi->get('Test\UA1Labs\Fire\TestClassAA');
             $this->assert(false);
-        } catch (DiException $e) {
+        } catch (NotFoundException $e) {
             $this->assert(true);
         }
     }
@@ -123,14 +147,14 @@ class DiTestCase extends TestCase
         try {
             $this->fireDi->getWith('UndefinedClass', []);
             $this->assert(false);
-        } catch (Exception $e) {
+        } catch (DiException $e) {
             $this->assert(true);
         }
     }
 
     public function testGetObjectCache()
     {
-        $this->fireDi->put('TestObject', new TestClassC());
+        $this->fireDi->set('TestObject', new TestClassC());
         $objectCache = $this->fireDi->getObjectCache();
 
         $this->should('Return an object cache array with a key "TestObject".');
@@ -143,7 +167,7 @@ class DiTestCase extends TestCase
     public function testClearObjectCache()
     {
         $this->should('Remove all objects from the object cache');
-        $this->fireDi->put('TestObject', new TestClassC());
+        $this->fireDi->set('TestObject', new TestClassC());
         $this->fireDi->clearObjectCache();
         $objectCache = $this->fireDi->getObjectCache();
         $this->assert(empty($objectCache));
@@ -184,12 +208,19 @@ class TestClassD
     }
 }
 
-class TestClassAA {
+class TestClassAA
+{
     public function __construct(TestClassBB $BB)
     {}
 }
 
-class TestClassBB {
+class TestClassBB
+{
     public function __construct(TestClassAA $AA)
+    {}
+}
+
+class TestClassCC {
+    public function __construct(TestClassDD $DD)
     {}
 }

--- a/UA1Labs/Fire/Di.TestCase.php
+++ b/UA1Labs/Fire/Di.TestCase.php
@@ -45,7 +45,7 @@ class DiTestCase extends TestCase
         $this->assert($this->fireDi instanceof Di);
     }
 
-    public function testPutObject()
+    public function testSetObject()
     {
         $this->should('Put an object in the cache without an exception.');
         try {
@@ -54,6 +54,48 @@ class DiTestCase extends TestCase
         } catch (DiException $e) {
             $this->assert(false);
         }
+
+        $this->should('Put an array in the cache.');
+        $this->fireDi->clearObjectCache();
+        $this->fireDi->set('TestObject', []);
+        $this->assert($this->fireDi->get('TestObject') === []);
+
+        $this->should('Put a string in the cache.');
+        $this->fireDi->clearObjectCache();
+        $this->fireDi->set('TestObject', 'Test');
+        $this->assert($this->fireDi->get('TestObject') === 'Test');
+    }
+
+    public function testSetCallable()
+    {
+        $callable = function() {
+            return new TestClassC;
+        };
+
+        $this->should('Allow me to set a callable object in the object cache.');
+        $this->fireDi->set('Test\Callable\Function', $callable);
+        $objectCache = $this->fireDi->getObjectCache();
+        $this->assert(
+            isset($objectCache['Test\Callable\Function'])
+            && $objectCache['Test\Callable\Function'] === $callable
+        );
+
+        $this->should('Allow me to call the object from cache and the callable function should be executed.');
+        $this->assert($this->fireDi->get('Test\Callable\Function') instanceof TestClassC);
+        $this->fireDi->clearObjectCache();
+
+        $this->should('Allow me to override a class definition with a callable.');
+        $testClassC = $this->fireDi->get('Test\UA1Labs\Fire\TestClassC');
+        $this->fireDi->set('Test\UA1Labs\Fire\TestClassC', $callable);
+        $objectCache = $this->fireDi->getObjectCache();
+        $this->assert(
+            isset($objectCache['Test\UA1Labs\Fire\TestClassC'])
+            && $objectCache['Test\UA1Labs\Fire\TestClassC'] === $callable
+        );
+
+        $this->should('Resolve "TestClassD" properly with the callable overridden.');
+        $testClassD = $this->fireDi->get('Test\UA1Labs\Fire\TestClassD');
+        $this->assert($testClassD instanceof TestClassD);
     }
 
     public function testHasObject()

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -61,14 +61,14 @@ class Di implements ContainerInterface
     }
 
     /**
-     * Sets an object into the object cache that is used to resolve dependencies.
+     * Puts an object into the object cache that is used to resolve dependencies.
      *
      * @param string $classname The classname the instance object should resolve for
-     * @param object|callable $instanceObject The instance object you want to return for the classname
+     * @param object|callable $entry The object or callable you'd like to place in the object cache
      */
-    public function set($classname, $instanceObject)
+    public function set($classname, $entry)
     {
-        $this->setCachedObject($classname, $instanceObject);
+        $this->setCachedObject($classname, $entry);
     }
 
     /**
@@ -91,9 +91,9 @@ class Di implements ContainerInterface
      * Attempts to retrieve an instance object of the given classname by resolving its
      * dependencies and creating an instance of the object.
      *
-     * @param $classname string The class you would like to instanciate
-     * @throws \UA1Labs\Fire\Di\NotFoundException If the class connot be resolved
-     * @return object The instanciated object based on the $classname
+     * @param $classname string The class you would like to instantiate
+     * @throws \UA1Labs\Fire\Di\NotFoundException If the class cannot be resolved
+     * @return object The instantiated object based on the $classname
      */
     public function get($classname)
     {

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -26,9 +26,9 @@ use \UA1Labs\Fire\DiException;
 class Di
 {
 
-    public const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
-    public const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
-    public const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s", FireDI found that the class dependency "%s" could not be found.';
+    const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
+    const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
+    const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s", FireDI found that the class dependency "%s" could not be found.';
 
     /**
      * A map that stores all class definitions.
@@ -67,7 +67,6 @@ class Di
      *
      * @param string $classname The classname the instance object should resolve for
      * @param object $instanceObject The instance object you want to return for the classname
-     * @return void
      */
     public function put($classname, $instanceObject)
     {
@@ -116,8 +115,6 @@ class Di
 
     /**
      * Clears the object cache.
-     *
-     * @return void
      */
     public function clearObjectCache()
     {
@@ -154,7 +151,6 @@ class Di
      *
      * @param string $classname The class you want to set the object cache for
      * @param object $object The object you want to set the object cache for
-     * @return void
      */
     private function setCachedObject($classname, $object)
     {
@@ -252,7 +248,6 @@ class Di
      * current class's depenencies to ensure we don't end up in an infinite loop.
      *
      * @param string $classname The class you would like to register the dependencies for.
-     * @return void
      */
     private function registerDependentClassDefinitions($classname)
     {
@@ -294,7 +289,6 @@ class Di
      *
      * @param string $classname The class you want to instanciate
      * @param array<mixed> $resolvedDependencies The class dependencies
-     * @return void
      */
     private function instanciateClass($classname, $resolvedDependencies, $cache = false)
     {

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -14,10 +14,10 @@
 
 namespace UA1Labs\Fire;
 
-use ReflectionClass;
-use UA1Labs\Fire\Di\Graph;
-use UA1Labs\Fire\Di\ClassDefinition;
-use UA1Labs\Fire\DiException;
+use \ReflectionClass;
+use \UA1Labs\Fire\Di\Graph;
+use \UA1Labs\Fire\Di\ClassDefinition;
+use \UA1Labs\Fire\DiException;
 
 /**
  * The Di class is what makes dependency injection possible. This class handles the
@@ -26,40 +26,40 @@ use UA1Labs\Fire\DiException;
 class Di
 {
 
-    const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
-    const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
-    const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s", FireDI found that the class dependency "%s" could not be found.';
+    public const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
+    public const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
+    public const ERROR_DEPENDENCY_NOT_FOUND = 'While trying to resolve class "%s", FireDI found that the class dependency "%s" could not be found.';
 
     /**
      * A map that stores all class definitions.
      *
-     * @var array<UA1Labs\Fire\Di\ClassDefinition>
+     * @var array<\UA1Labs\Fire\Di\ClassDefinition>
      */
-    private $_classDefinitions;
+    private $classDefinitions;
 
     /**
-     * Stores singleton object that have been registered as singleton type class.
+     * Stores objects and callables for resolving depedencies.
      *
-     * @var array
+     * @var array<mixed>
      */
-    private $_objectCache;
+    private $objectCache;
 
     /**
      * A dependency graph containing information about classes
      * and their dependencies.
      *
-     * @var UA1Labs\Fire\Di\Graph
+     * @var \UA1Labs\Fire\Di\Graph
      */
-    private $_classDependencyGraph;
+    private $classDependencyGraph;
 
     /**
      * The class constructor.
      */
     public function __construct()
     {
-        $this->_classDefinitions = [];
-        $this->_objectCache = [];
-        $this->_classDependencyGraph = new Graph();
+        $this->classDefinitions = [];
+        $this->objectCache = [];
+        $this->classDependencyGraph = new Graph();
     }
 
     /**
@@ -71,7 +71,7 @@ class Di
      */
     public function put($classname, $instanceObject)
     {
-        $this->_setCachedObject($classname, $instanceObject);
+        $this->setCachedObject($classname, $instanceObject);
     }
 
     /**
@@ -83,7 +83,7 @@ class Di
      */
     public function get($classname)
     {
-        return $this->_resolveInstanceObject($classname);
+        return $this->resolveInstanceObject($classname);
     }
 
     /**
@@ -97,11 +97,11 @@ class Di
     {
         // if the class doesn't have a class definition we should attempt
         // to register the class definition
-        if (!$this->_isClassDefinitionRegistered($classname)) {
-            $this->_registerClassDefinition($classname);
+        if (!$this->isClassDefinitionRegistered($classname)) {
+            $this->registerClassDefinition($classname);
         }
 
-        return $this->_instanciateClass($classname, $dependencies);
+        return $this->instanciateClass($classname, $dependencies);
     }
 
     /**
@@ -111,7 +111,7 @@ class Di
      */
     public function getObjectCache()
     {
-        return $this->_objectCache;
+        return $this->objectCache;
     }
 
     /**
@@ -121,7 +121,7 @@ class Di
      */
     public function clearObjectCache()
     {
-        $this->_objectCache = [];
+        $this->objectCache = [];
     }
 
     /**
@@ -129,9 +129,9 @@ class Di
      *
      * @return boolean
      */
-    private function _isObjectCached($classname)
+    private function isObjectCached($classname)
     {
-        return isset($this->_objectCache[$classname]);
+        return isset($this->objectCache[$classname]);
     }
 
     /**
@@ -140,10 +140,10 @@ class Di
      * @param string $classname The classname you want to obtain the object for.
      * @return object|null
      */
-    private function _getCachedObject($classname)
+    private function getCachedObject($classname)
     {
-        if ($this->_isObjectCached($classname)) {
-            return $this->_objectCache[$classname];
+        if ($this->isObjectCached($classname)) {
+            return $this->objectCache[$classname];
         }
 
         return null;
@@ -156,9 +156,9 @@ class Di
      * @param object $object The object you want to set the object cache for
      * @return void
      */
-    private function _setCachedObject($classname, $object)
+    private function setCachedObject($classname, $object)
     {
-        $this->_objectCache[$classname] = $object;
+        $this->objectCache[$classname] = $object;
     }
 
     /**
@@ -167,9 +167,9 @@ class Di
      * @param string $classname
      * @return boolean
      */
-    private function _isClassDefinitionRegistered($classname)
+    private function isClassDefinitionRegistered($classname)
     {
-        return isset($this->_classDefinitions[$classname]);
+        return isset($this->classDefinitions[$classname]);
     }
 
     /**
@@ -179,18 +179,18 @@ class Di
      * @throws DiException if the class does not exist
      * @return void
      */
-    private function _registerClassDefinition($classname)
+    private function registerClassDefinition($classname)
     {
         if (!class_exists($classname)) {
             $errorMessage = sprintf(self::ERROR_CLASS_NOT_FOUND, $classname);
             throw new DiException($errorMessage);
         }
 
-        $this->_classDefinitions[$classname] = new ClassDefinition($classname);
-        $this->_classDependencyGraph->addResource($classname);
-        $this->_classDependencyGraph->addDependencies(
+        $this->classDefinitions[$classname] = new ClassDefinition($classname);
+        $this->classDependencyGraph->addResource($classname);
+        $this->classDependencyGraph->addDependencies(
             $classname,
-            $this->_classDefinitions[$classname]->dependencies
+            $this->classDefinitions[$classname]->dependencies
         );
     }
 
@@ -200,10 +200,10 @@ class Di
      * @param string $classname
      * @return object|void
      */
-    private function _getClassDefinition($classname)
+    private function getClassDefinition($classname)
     {
-        if ($this->_isClassDefinitionRegistered($classname)) {
-            return $this->_classDefinitions[$classname];
+        if ($this->isClassDefinitionRegistered($classname)) {
+            return $this->classDefinitions[$classname];
         }
 
         return null;
@@ -217,31 +217,31 @@ class Di
      * @param $classname The classname of the instance object you would like to resolve
      * @return mixed The resolved instance object
      */
-    private function _resolveInstanceObject($classname)
+    private function resolveInstanceObject($classname)
     {
         // return object from the object cache if it is there
-        if ($this->_isObjectCached($classname)) {
-            return $this->_getCachedObject($classname);
+        if ($this->isObjectCached($classname)) {
+            return $this->getCachedObject($classname);
         }
 
         // if the class doesn't have a class definition we should attempt
         // to register the class definition
-        if (!$this->_isClassDefinitionRegistered($classname)) {
-            $this->_registerClassDefinition($classname);
+        if (!$this->isClassDefinitionRegistered($classname)) {
+            $this->registerClassDefinition($classname);
         }
 
         // recursively register dependency class definitions
-        $this->_registerDependentClassDefinitions($classname);
+        $this->registerDependentClassDefinitions($classname);
 
-        $classDefinition = $this->_getClassDefinition($classname);
+        $classDefinition = $this->getClassDefinition($classname);
         $dependencies = $classDefinition->dependencies;
 
         $di = [];
         foreach ($dependencies as $dependency) {
             //set $di[] with all dependencies and invoke
-            $di[] = $this->_resolveInstanceObject($dependency);
+            $di[] = $this->resolveInstanceObject($dependency);
         }
-        return $this->_instanciateClass($classname, $di, true);
+        return $this->instanciateClass($classname, $di, true);
     }
 
     /**
@@ -254,15 +254,15 @@ class Di
      * @param string $classname The class you would like to register the dependencies for.
      * @return void
      */
-    private function _registerDependentClassDefinitions($classname)
+    private function registerDependentClassDefinitions($classname)
     {
-        $classDefinition = $this->_getClassDefinition($classname);
+        $classDefinition = $this->getClassDefinition($classname);
         foreach ($classDefinition->dependencies as $dependency) {
-            if (!$this->_isClassDefinitionRegistered($dependency)) {
-                $this->_registerClassDefinition($dependency);
+            if (!$this->isClassDefinitionRegistered($dependency)) {
+                $this->registerClassDefinition($dependency);
             }
-            $this->_circularDependencyErrorCheck($classname);
-            $this->_registerDependentClassDefinitions($dependency);
+            $this->circularDependencyErrorCheck($classname);
+            $this->registerDependentClassDefinitions($dependency);
         }
     }
 
@@ -274,9 +274,9 @@ class Di
      * @throws DiException
      * @return array<string> The order we need to resolve dependencies
      */
-    private function _circularDependencyErrorCheck($classname)
+    private function circularDependencyErrorCheck($classname)
     {
-        $error = $this->_classDependencyGraph->runDependencyCheck($classname);
+        $error = $this->classDependencyGraph->runDependencyCheck($classname);
         if ($error) {
             switch ($error->code) {
                 case 2:
@@ -286,7 +286,7 @@ class Di
             }
         }
 
-        $this->_classDependencyGraph->resetDependencyCheck();
+        $this->classDependencyGraph->resetDependencyCheck();
     }
 
     /**
@@ -296,15 +296,15 @@ class Di
      * @param array<mixed> $resolvedDependencies The class dependencies
      * @return void
      */
-    private function _instanciateClass($classname, $resolvedDependencies, $cache = false)
+    private function instanciateClass($classname, $resolvedDependencies, $cache = false)
     {
-        $classDefinition = $this->_getClassDefinition($classname);
+        $classDefinition = $this->getClassDefinition($classname);
         $classDef = $classDefinition->classDef;
         if ($cache) {
-            if (!$this->_isObjectCached($classname)) {
-                $this->_setCachedObject($classname, $classDef->newInstanceArgs($resolvedDependencies));
+            if (!$this->isObjectCached($classname)) {
+                $this->setCachedObject($classname, $classDef->newInstanceArgs($resolvedDependencies));
             }
-            return $this->_getCachedObject($classname);
+            return $this->getCachedObject($classname);
         } else {
             $classDef = $classDefinition->classDef;
             return $classDef->newInstanceArgs($resolvedDependencies);

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -28,8 +28,6 @@ use \Psr\Container\ContainerInterface;
 class Di implements ContainerInterface
 {
 
-    const ERROR_NOT_FOUND_IN_CONTAINER = '"%s" could not be resolved by FireDI.';
-
     /**
      * A map that stores all class definitions.
      *
@@ -100,7 +98,7 @@ class Di implements ContainerInterface
     public function get($classname)
     {
         if (!$this->has($classname)) {
-            $errorMessage = sprintf(self::ERROR_NOT_FOUND_IN_CONTAINER, $classname);
+            $errorMessage = sprintf(NotFoundException::ERROR_NOT_FOUND_IN_CONTAINER, $classname);
             throw new NotFoundException($errorMessage);
         }
         return $this->getCachedObject($classname);

--- a/UA1Labs/Fire/Di.php
+++ b/UA1Labs/Fire/Di.php
@@ -156,12 +156,18 @@ class Di implements ContainerInterface
      * Returns the cached object if it exists. Otherwise it returns null.
      *
      * @param string $classname The classname you want to obtain the object for.
-     * @return object|null
+     * @return mixed|null
      */
     private function getCachedObject($classname)
     {
         if ($this->isObjectCached($classname)) {
-            return $this->objectCache[$classname];
+            $cachedObject = $this->objectCache[$classname];
+
+            if (is_callable($cachedObject)) {
+                return $cachedObject();
+            }
+
+            return $cachedObject;
         }
 
         return null;
@@ -171,7 +177,7 @@ class Di implements ContainerInterface
      * Sets the object in object cache.
      *
      * @param string $classname The class you want to set the object cache for
-     * @param object $object The object you want to set the object cache for
+     * @param mixed $object The object you want to set the object cache for
      */
     private function setCachedObject($classname, $object)
     {

--- a/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
+++ b/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
@@ -14,16 +14,16 @@
 
 namespace Test\UA1Labs\Fire\Di;
 
-use UA1Labs\Fire\Test\TestCase;
-use UA1Labs\Fire\Di\ClassDefinition;
-use ReflectionClass;
+use \UA1Labs\Fire\Test\TestCase;
+use \UA1Labs\Fire\Di\ClassDefinition;
+use \ReflectionClass;
 
 class ClassDefinitionTestCase extends TestCase
 {
     /**
      * The FireDi ClassDefinition Class
      *
-     * @var ClassDefinition
+     * @var \UA1Lab\Fire\Di\ClassDefinition
      */
     private $classDefinition;
 

--- a/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
+++ b/UA1Labs/Fire/Di/ClassDefinition.TestCase.php
@@ -25,16 +25,16 @@ class ClassDefinitionTestCase extends TestCase
      *
      * @var ClassDefinition
      */
-    private $_classDefinition;
+    private $classDefinition;
 
     public function beforeEach()
     {
-        $this->_classDefinition = new ClassDefinition('Test\UA1Labs\Fire\Di\MyTestClass');
+        $this->classDefinition = new ClassDefinition('Test\UA1Labs\Fire\Di\MyTestClass');
     }
 
     public function afterEach()
     {
-        unset($this->_classDefinition);
+        unset($this->classDefinition);
     }
 
     public function testConstructor()
@@ -43,15 +43,15 @@ class ClassDefinitionTestCase extends TestCase
         $this->assert(true);
 
         $this->should('Have set a serviceId of "Test\UA1Labs\Fire\Di\MyTestClass".');
-        $this->assert($this->_classDefinition->serviceId === 'Test\UA1Labs\Fire\Di\MyTestClass');
+        $this->assert($this->classDefinition->serviceId === 'Test\UA1Labs\Fire\Di\MyTestClass');
 
         $this->should('Have set a classDef as a ReflectionClass object.');
-        $this->assert($this->_classDefinition->classDef instanceof ReflectionClass);
+        $this->assert($this->classDefinition->classDef instanceof ReflectionClass);
 
         $this->should('Have set a dependency of "Test\UA1Labs\Fire\Di\MyDependentClass"');
         $this->assert(
-            isset($this->_classDefinition->dependencies[0])
-            && $this->_classDefinition->dependencies[0] === 'Test\UA1Labs\Fire\Di\MyDependentClass'
+            isset($this->classDefinition->dependencies[0])
+            && $this->classDefinition->dependencies[0] === 'Test\UA1Labs\Fire\Di\MyDependentClass'
         );
     }
 

--- a/UA1Labs/Fire/Di/ClassDefinition.php
+++ b/UA1Labs/Fire/Di/ClassDefinition.php
@@ -14,8 +14,8 @@
 
 namespace UA1Labs\Fire\Di;
 
-use ReflectionClass;
-use UA1Labs\Fire\DiException;
+use \ReflectionClass;
+use \UA1Labs\Fire\DiException;
 
 /**
  * This class is meant to wrap a class being registered with FireDI.
@@ -33,7 +33,7 @@ class ClassDefinition
     /**
      * A reflection object that defines this particular service.
      *
-     * @var ReflectionClass
+     * @var \ReflectionClass
      */
     public $classDef;
 
@@ -52,7 +52,6 @@ class ClassDefinition
      * runtime environment.
      *
      * @param string $classname The class you would like to wrap in an ulfberhtservice.
-     * @return void
      */
     public function __construct($classname)
     {

--- a/UA1Labs/Fire/Di/ClassDefinition.php
+++ b/UA1Labs/Fire/Di/ClassDefinition.php
@@ -16,6 +16,7 @@ namespace UA1Labs\Fire\Di;
 
 use \ReflectionClass;
 use \UA1Labs\Fire\DiException;
+use \ReflectionException;
 
 /**
  * This class is meant to wrap a class being registered with FireDI.
@@ -65,11 +66,15 @@ class ClassDefinition
             $parameters = $constructor->getParameters();
             if (!empty($parameters)) {
                 foreach ($parameters as $parameter) {
-                    $dependency = $parameter->getClass();
-                    if ($dependency) {
-                        $this->dependencies[] = $dependency->getName();
-                    } else {
-                        $this->dependencies[] = '';
+                    try {
+                        $dependency = $parameter->getClass();
+                        if ($dependency) {
+                            $this->dependencies[] = $dependency->getName();
+                        } else {
+                            $this->dependencies[] = '';
+                        }
+                    } catch (ReflectionException $e) {
+                        throw new DiException($e->getMessage());
                     }
                 }
             }

--- a/UA1Labs/Fire/Di/Graph.TestCase.php
+++ b/UA1Labs/Fire/Di/Graph.TestCase.php
@@ -14,9 +14,9 @@
 
 namespace Test\UA1Labs\Fire\Di;
 
-use UA1Labs\Fire\Test\TestCase;
-use UA1Labs\Fire\Di\Graph;
-use Throwable;
+use \UA1Labs\Fire\Test\TestCase;
+use \UA1Labs\Fire\Di\Graph;
+use \Throwable;
 
 class GraphTestCase extends TestCase
 {
@@ -25,16 +25,16 @@ class GraphTestCase extends TestCase
      *
      * @var Graph
      */
-    private $_graph;
+    private $graph;
 
     public function beforeEach()
     {
-        $this->_graph = new Graph();
+        $this->graph = new Graph();
     }
 
     public function afterEach()
     {
-        unset($this->_graph);
+        unset($this->graph);
     }
 
     public function testConstructor()
@@ -46,44 +46,44 @@ class GraphTestCase extends TestCase
     public function testAddResource()
     {
         $this->should('Add a resource to the resource graph.');
-        $this->_graph->addResource('Resource');
-        $this->assert($this->_graph->isResource('Resource'));
+        $this->graph->addResource('Resource');
+        $this->assert($this->graph->isResource('Resource'));
     }
 
     public function testAddDependencies()
     {
         $this->should('Add dependencies to a resource.');
         $dependencies = ['Dependency1', 'Dependency2'];
-        $this->_graph->addResource('MyResource');
-        $this->_graph->addDependencies('MyResource', $dependencies);
-        $this->assert($this->_graph->getDependencies('MyResource') === $dependencies);
+        $this->graph->addResource('MyResource');
+        $this->graph->addDependencies('MyResource', $dependencies);
+        $this->assert($this->graph->getDependencies('MyResource') === $dependencies);
     }
 
     public function testAddDependency()
     {
         $this->should('Add a dependency to a resource.');
-        $this->_graph->addResource('MyResource');
-        $this->_graph->addDependency('MyResource', 'Dependency1');
-        $this->assert($this->_graph->getDependencies('MyResource') === ['Dependency1']);
+        $this->graph->addResource('MyResource');
+        $this->graph->addDependency('MyResource', 'Dependency1');
+        $this->assert($this->graph->getDependencies('MyResource') === ['Dependency1']);
     }
 
     public function testRunDependencyCheck()
     {
         $this->should('Return an error code of "1" (Resourece Not Found).');
-        $this->_graph->addResource('Resource1');
-        $this->_graph->addDependency('Resource1', 'Resource2');
-        $check = $this->_graph->runDependencyCheck('Resource1');
+        $this->graph->addResource('Resource1');
+        $this->graph->addDependency('Resource1', 'Resource2');
+        $check = $this->graph->runDependencyCheck('Resource1');
         $this->assert(isset($check->code) && $check->code === 1);
 
         $this->should('Contain which resource was missing.');
         $this->assert(isset($check->resourceId) && $check->resourceId === 'Resource2');
 
-        $this->_graph->resetDependencyCheck();
+        $this->graph->resetDependencyCheck();
 
         $this->should('Return and error code "2" (Circular Dependnecy).');
-        $this->_graph->addResource('Resource2');
-        $this->_graph->addDependency('Resource2', 'Resource1');
-        $check = $this->_graph->runDependencyCheck('Resource1');
+        $this->graph->addResource('Resource2');
+        $this->graph->addDependency('Resource2', 'Resource1');
+        $check = $this->graph->runDependencyCheck('Resource1');
         $this->assert(isset($check->code) && $check->code === 2);
 
         $this->should('Contain the resource of which caused the circular dependency.');
@@ -93,25 +93,25 @@ class GraphTestCase extends TestCase
     public function testGetDependencyResolveOrder()
     {
         $this->should('Resolve dependencies in the order they need to be resolved.');
-        $this->_graph->addResource('Resource1');
-        $this->_graph->addResource('Resource2');
-        $this->_graph->addResource('Resource3');
-        $this->_graph->addDependencies('Resource1', ['Resource2', 'Resource3']);
-        $this->_graph->addDependency('Resource2', 'Resource3');
-        $this->_graph->runDependencyCheck('Resource1');
-        $resolveOrder = $this->_graph->getDependencyResolveOrder();
+        $this->graph->addResource('Resource1');
+        $this->graph->addResource('Resource2');
+        $this->graph->addResource('Resource3');
+        $this->graph->addDependencies('Resource1', ['Resource2', 'Resource3']);
+        $this->graph->addDependency('Resource2', 'Resource3');
+        $this->graph->runDependencyCheck('Resource1');
+        $resolveOrder = $this->graph->getDependencyResolveOrder();
         $this->assert($resolveOrder === ['Resource3', 'Resource2']);
     }
 
     public function testResetDependencyCheck()
     {
         $this->should('Reset a dependency check.');
-        $this->_graph->addResource('Resource1');
-        $this->_graph->addResource('Resource2');
-        $this->_graph->addDependency('Resouce1', 'Resource2');
-        $this->_graph->runDependencyCheck('Resouce1');
-        $this->_graph->resetDependencyCheck();
-        $resolveOrder = $this->_graph->getDependencyResolveOrder('Resource1');
+        $this->graph->addResource('Resource1');
+        $this->graph->addResource('Resource2');
+        $this->graph->addDependency('Resouce1', 'Resource2');
+        $this->graph->runDependencyCheck('Resouce1');
+        $this->graph->resetDependencyCheck();
+        $resolveOrder = $this->graph->getDependencyResolveOrder('Resource1');
         $this->assert(empty($resolveOrder));
     }
 

--- a/UA1Labs/Fire/Di/Graph.TestCase.php
+++ b/UA1Labs/Fire/Di/Graph.TestCase.php
@@ -23,7 +23,7 @@ class GraphTestCase extends TestCase
     /**
      * The FireDi Graph Class
      *
-     * @var Graph
+     * @var \UA1Labs\Fire\Di\Graph
      */
     private $graph;
 

--- a/UA1Labs/Fire/Di/Graph.php
+++ b/UA1Labs/Fire/Di/Graph.php
@@ -14,7 +14,7 @@
 
 namespace UA1Labs\Fire\Di;
 
-use stdClass;
+use \stdClass;
 
 /**
  * This class makes it to easy to manage a dependency network
@@ -64,14 +64,14 @@ class Graph
         $this->resolved = [];
         $this->unresolved = [];
         $this->resourceGraph = [];
-        $this->errorConfig();
+        $this->initErrorConfig();
     }
 
     /**
      * This method is used to add a resource to the dependecy graph.
      *
      * @param string $resourseId A unique ID that identifies a resource
-     * @return UA1Labs\Fire\Di\Graph
+     * @return \UA1Labs\Fire\Di\Graph
      */
     public function addResource($resourseId)
     {
@@ -99,7 +99,7 @@ class Graph
      *     want to add dependencies to.
      * @param array $dependencies An array that contains the dependencies you want
      *     to apply to the resource.
-     * @return UA1Labs\Fire\Di\Graph
+     * @return \UA1Labs\Fire\Di\Graph
      */
     public function addDependencies($resourceId, array $dependencies)
     {
@@ -114,7 +114,7 @@ class Graph
      *    want to add dependency to.
      * @param string $dependency A var that contains the dependency you want
      *    to apply to the resource.
-     * @return UA1Labs\Fire\Di\Graph
+     * @return \UA1Labs\Fire\Di\Graph
      */
     public function addDependency($resourceId, $dependency)
     {
@@ -176,8 +176,6 @@ class Graph
     /**
      * This method resets the status of all properies required to run another
      * dependency check.
-     *
-     * @return void
      */
     public function resetDependencyCheck()
     {
@@ -187,10 +185,8 @@ class Graph
 
     /**
      * This method is a helper method to set the default error config values.
-     *
-     * @return void
      */
-    private function errorConfig()
+    private function initErrorConfig()
     {
         //error code config
         $error1 = (object) [

--- a/UA1Labs/Fire/Di/NotFoundException.php
+++ b/UA1Labs/Fire/Di/NotFoundException.php
@@ -23,4 +23,6 @@ use \Psr\Container\NotFoundExceptionInterface;
 class NotFoundException extends Exception implements NotFoundExceptionInterface
 {
 
+    const ERROR_NOT_FOUND_IN_CONTAINER = '"%s" could not be resolved by FireDI.';
+
 }

--- a/UA1Labs/Fire/Di/NotFoundException.php
+++ b/UA1Labs/Fire/Di/NotFoundException.php
@@ -12,18 +12,15 @@
  * @copyright Copyright (c) UA1 Labs
  */
 
-namespace UA1Labs\Fire;
+namespace UA1Labs\Fire\Di;
 
 use \Exception;
-use \Psr\Container\ContainerExceptionInterface;
+use \Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Exception thrown from the FireDI library.
  */
-class DiException extends Exception implements ContainerExceptionInterface
+class NotFoundException extends Exception implements NotFoundExceptionInterface
 {
-
-    const ERROR_CLASS_NOT_FOUND = 'Class "%s" does not exist and it definition cannot be registered with FireDI.';
-    const ERROR_CIRCULAR_DEPENDENCY = 'While trying to resolve class "%s", FireDI found that there was a cirular dependency caused by the class "%s".';
 
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require": {
         "ua1-labs/firetest": "2.*",
-        "ua1-labs/firebug": "1.*"
+        "ua1-labs/firebug": "1.*",
+        "psr/container": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,11 @@
         "test": "php vendor/ua1-labs/firetest/scripts/runner.php --dir=/UA1Labs --ext=.TestCase.php"
     },
     "require": {
-        "ua1-labs/firetest": "2.*",
         "ua1-labs/firebug": "1.*",
         "psr/container": "^1.0"
+    },
+    "require-dev": {
+        "ua1-labs/firetest": "2.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ua1-labs/firedi",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "description": "FireDI is a powerful and light weight PHP dependency injection library.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
* Updates to be compliant with PRS-2 standard.
* Updates to bring the DI Container up to PSR-11 standard.
* Moved ua1-labs/firetest to a require-dev dependency for composer.
* Created Di::set() to allow for the ability to place your own dependencies and added support for Di::set() to take in a callable that will resolve be resolved as part of the Di::get();
* Add MIT LICENSE